### PR TITLE
Handle non-array allOf gracefully

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ function getAllOf(schema) {
       return getAllOf(allSchema)
     }))
   } else {
+    delete schema.allOf
     return [schema]
   }
 }

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -57,6 +57,14 @@ describe('module', function() {
     })
   })
 
+  it('handles non-array allOf', function() {
+    var result = merger({
+      allOf: {}
+    })
+
+    expect(result).to.eql({})
+  })
+
   describe('simple resolve functionality', function() {
     it('merges with default resolver if not defined resolver', function() {
       var result = merger({


### PR DESCRIPTION
The PR addresses an issue with `merger` running into infinite recursion.
`getAllOf` does not remove `allOf` property at the moment if it's not an array. It bails out if there is a property with key `allOf`, but its value is not an array.