### PR TITLE
Add "deep" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ mergeAllOf(schema, {
 })
 ```
 
+**deep** boolean, default *true*
+If false, resolves only the top-level `allOf` keyword in the schema.
+
+If true, resolves all `allOf` keywords in the schema.
+
 The function is passed:
 
 - **values** an array of the conflicting values that need to be resolved

--- a/src/index.js
+++ b/src/index.js
@@ -443,7 +443,8 @@ function merger(rootSchema, options, totalSchemas) {
   totalSchemas = totalSchemas || []
   options = defaultsDeep(options, {
     ignoreAdditionalProperties: false,
-    resolvers: defaultResolvers
+    resolvers: defaultResolvers,
+    deep: true
   })
 
   function mergeSchemas(schemas, base, parents) {
@@ -470,8 +471,7 @@ function merger(rootSchema, options, totalSchemas) {
     schemas = schemas.filter(isPlainObject)
 
     var allKeys = allUniqueKeys(schemas)
-
-    if (contains(allKeys, 'allOf')) {
+    if (options.deep && contains(allKeys, 'allOf')) {
       return merger({
         allOf: schemas
       }, options, totalSchemas)

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -134,4 +134,62 @@ describe('options', function() {
       foo: 7
     })
   })
+
+  it('merges deep by default', function() {
+    var result = merger({
+      allOf: [{
+        properties: {
+          foo: {type: 'string'},
+          bar: {
+            allOf: [{
+              properties: {
+                baz: {type: 'string'}
+              }
+            }]
+          }
+        }
+      }]
+    })
+
+    expect(result).to.eql({
+      properties: {
+        foo: {type: 'string'},
+        bar: {
+          properties: {
+            baz: {type: 'string'}
+          }
+        }
+      }
+    })
+  })
+
+  it('doesn\'t merge deep when deep is false', function() {
+    var result = merger({
+      allOf: [{
+        properties: {
+          foo: {type: 'string'},
+          bar: {
+            allOf: [{
+              properties: {
+                baz: {type: 'string'}
+              }
+            }]
+          }
+        }
+      }]
+    }, {deep: false})
+
+    expect(result).to.eql({
+      properties: {
+        foo: {type: 'string'},
+        bar: {
+          allOf: [{
+            properties: {
+              baz: {type: 'string'}
+            }
+          }]
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
When "deep" is set to false, then the merger function only merges a top-level `allOf`, if present.

By default, it is set to true, for backwards compatibility.